### PR TITLE
Release 7.0.4: managed runtime health and clean MCP protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [7.0.4] - Unreleased
 
 - Report prepared and running managed-runtime versions separately in MCP health.
 - Use the canonical PyMuPDF import so dependency deprecation messages do not corrupt MCP stdout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [7.0.4] - Unreleased
+## [7.0.4] - 2026-09-07
 
 - Report prepared and running managed-runtime versions separately in MCP health.
 - Use the canonical PyMuPDF import so dependency deprecation messages do not corrupt MCP stdout.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Report prepared and running managed-runtime versions separately in MCP health.
+- Use the canonical PyMuPDF import so dependency deprecation messages do not corrupt MCP stdout.
+- Exercise the automation-owned render worker in queue integration tests.
+
 ## [7.0.3] - 2026-08-22
 
 core `python-hwpx 6.3.0`(왕복 충실도 트레인)을 따르는 패치 릴리스입니다.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   </p>
 </p>
 
-<!-- release-state: unreleased-candidate -->
+<!-- release-state: release-approved -->
 > [!NOTE]
 > 아직 공개되지 않은 7.0.4 후보입니다.
 > 후보 조합: `python-hwpx 6.3.0 → python-hwpx-automation 7.0.4 → hwpx-plugin 2.1.0`.

--- a/README.md
+++ b/README.md
@@ -12,16 +12,15 @@
   </p>
 </p>
 
-<!-- release-state: released -->
+<!-- release-state: unreleased-candidate -->
 > [!NOTE]
-> 공개 트레인: `python-hwpx 6.3.0 → python-hwpx-automation 7.0.3 →
-> hwpx-plugin 2.0.2` (2026-08-22 왕복 충실도 트레인 — 계약 `8c278ebd5becba08`,
-> floor-only 델타로 도구 표면 불변.
-> Windows 저장 수리 패치 트레인 — 저장 수리 #98·업로드 경로 안내
-> #75, core와 계약 `34a91560759dc47a` 불변).
-> 공개 좌표는 원격 진실(core·automation PyPI와 plugin GitHub
-> Release·marketplace·실제 marketplace 설치) 관찰 후에만
-> 승격됩니다 — [릴리스 runbook](docs/release-runbook.md)
+> 아직 공개되지 않은 7.0.4 후보입니다.
+> 후보 조합: `python-hwpx 6.3.0 → python-hwpx-automation 7.0.4 → hwpx-plugin 2.1.0`.
+> 공개 트레인: `python-hwpx 6.3.0 → python-hwpx-automation 7.0.3 → hwpx-plugin 2.0.3`.
+> 계약은 `8c278ebd5becba08`이며 도구 표면과 최소 호환 버전은 유지합니다.
+> 공개 좌표는 core·automation PyPI와 plugin GitHub
+> Release·marketplace·실제 marketplace 설치 관찰 후에만 승격합니다.
+> [릴리스 runbook](docs/release-runbook.md)
 
 [python-hwpx](https://github.com/airmang/python-hwpx) 엔진 위에서 문서 저작·
 양식 채움·시험지 조판·안전한 에이전트 워크플로를 제공하는 응용 계층입니다.

--- a/compat/hwpx-mcp-server/pyproject.toml
+++ b/compat/hwpx-mcp-server/pyproject.toml
@@ -12,7 +12,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hwpx-mcp-server"
-version = "7.0.3"
+version = "7.0.4"
 description = "Compatibility shell — installs python-hwpx-automation[mcp] under its former name."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,7 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = ["python-hwpx-automation[mcp]==7.0.3"]
+dependencies = ["python-hwpx-automation[mcp]==7.0.4"]
 
 [project.scripts]
 "hwpx-mcp-server" = "hwpx_automation.mcp_cli:main"
@@ -37,12 +37,12 @@ dependencies = ["python-hwpx-automation[mcp]==7.0.3"]
 # 명령은 성공하고 아무것도 설치되지 않는다 — 실측으로 확인했다. 조용히 아무
 # 일도 안 일어나는 설치 안내는 없는 것만 못하다.
 [project.optional-dependencies]
-mcp = ["python-hwpx-automation[mcp]==7.0.3"]
-hwp = ["python-hwpx-automation[hwp]==7.0.3"]
-http = ["python-hwpx-automation[http]==7.0.3"]
-ingest = ["python-hwpx-automation[ingest]==7.0.3"]
-oracle = ["python-hwpx-automation[oracle]==7.0.3"]
-vision = ["python-hwpx-automation[vision]==7.0.3"]
+mcp = ["python-hwpx-automation[mcp]==7.0.4"]
+hwp = ["python-hwpx-automation[hwp]==7.0.4"]
+http = ["python-hwpx-automation[http]==7.0.4"]
+ingest = ["python-hwpx-automation[ingest]==7.0.4"]
+oracle = ["python-hwpx-automation[oracle]==7.0.4"]
+vision = ["python-hwpx-automation[vision]==7.0.4"]
 
 [project.urls]
 Homepage = "https://github.com/airmang/python-hwpx-automation"

--- a/docs/architecture/form-fill-runtime-owner.json
+++ b/docs/architecture/form-fill-runtime-owner.json
@@ -11,7 +11,7 @@
   "canonical": {
     "pythonFiles": 15,
     "loc": 5060,
-    "manifestSha256": "d00f97e320041b58e45df34485875d7e40bc7b1c9247cc0661ca151973c4daa7",
+    "manifestSha256": "abaee6e1379a31610700da754df9d484d7ed4385c83cca4cfe9f1da043b5e4f9",
     "nomenclatureRefrozenFrom": {
       "loc": 5060,
       "manifestSha256": "9da1c81298ca242f05b81f17cfac3dbe3fc5235a1a74b14f0d00be726dda70f5",
@@ -20,8 +20,8 @@
     "refrozenNote": "WP-F (core 6.0 namespace adaptation): seal.py's document.add_image(...) call and template_formfit.py's doc.export_text() call moved to document.media.add_image(...)/doc.text.plain() (design §2.6). Same line counts, no behavior change.",
     "refrozenFrom": {
       "loc": 5060,
-      "manifestSha256": "603a0a1bee6cf45a5f6e847166264c8b25e15485cc31ba286c5121fbb10ccb7a",
-      "reason": "quality.py docstring oracle-path rename (5.0 boundary close); see nested refrozenFrom chain for earlier history"
+      "manifestSha256": "d00f97e320041b58e45df34485875d7e40bc7b1c9247cc0661ca151973c4daa7",
+      "reason": "7.0.4 uses import pymupdf as fitz to prevent legacy import warnings corrupting MCP stdout; ownership, file counts and LOC are unchanged."
     }
   },
   "moduleMap": {

--- a/docs/architecture/visual-runtime-owner.json
+++ b/docs/architecture/visual-runtime-owner.json
@@ -1,109 +1,109 @@
 {
- "schemaVersion": "hwpx-mcp.visual-runtime-owner/v1",
- "canonicalOwner": "hwpx_automation.office.rendering",
- "sourceCompatibilityOwner": "python-hwpx 4.x",
- "source": {
-  "head": "3720196aa3ad4c4885059573c23bd7a8293302fb",
-  "pythonFiles": 11,
-  "loc": 2667,
-  "manifestSha256": "1d10fab2feba5b892bc2d6ea7a5af621b11394a6f3a65de0cd2861ce5445c758",
-  "publicSurfaceSha256": "66f3c71e9a03f714de4ab4c6259f362549d4eb0b0d8ab94282c99446cc500481"
- },
- "canonical": {
-  "status": "canonical",
-  "pythonFiles": 10,
-  "loc": 2718,
-  "manifestSha256": "1ecd84fee985862dc93318b545498b151bfc9118b72acff2944b5c20d9121158",
-  "nomenclatureRefrozenFrom": {
-   "loc": 2704,
-   "manifestSha256": "9587ff0e479f7d221e5202a51ee3635293794a16272e1e89a68b9a3dfd1e7676",
-   "reason": "Canonical product ownership wording changed from MCP to automation; protocol and behavior are unchanged."
+  "schemaVersion": "hwpx-mcp.visual-runtime-owner/v1",
+  "canonicalOwner": "hwpx_automation.office.rendering",
+  "sourceCompatibilityOwner": "python-hwpx 4.x",
+  "source": {
+    "head": "3720196aa3ad4c4885059573c23bd7a8293302fb",
+    "pythonFiles": 11,
+    "loc": 2667,
+    "manifestSha256": "1d10fab2feba5b892bc2d6ea7a5af621b11394a6f3a65de0cd2861ce5445c758",
+    "publicSurfaceSha256": "66f3c71e9a03f714de4ab4c6259f362549d4eb0b0d8ab94282c99446cc500481"
   },
-  "frozenAtNote": "S-104 동결값 loc=2001 sha=4b63f85703896fe8…에서 재계산. 코드가 바뀐 게 아니라 소유자가 core에 있던 4개 모듈을 받았기 때문이다. 동결은 드리프트를 막으려는 것이지 이동을 막으려는 것이 아니므로, 이유와 함께 다시 얼린다.",
-  "refrozenFrom": {
-   "loc": 2704,
-   "manifestSha256": "0b858d49694b9b11293b52b379a4351a55504e56ee9cc17707399c6821f9f02e",
-   "reason": "Lazy automation rendering exports gained TYPE_CHECKING declarations and a runtime patch-preserving resolver; runtime behavior and tool contract are unchanged."
-  }
- },
- "packageFiles": [
-  "__init__.py",
-  "block_splits.py",
-  "detectors.py",
-  "diff.py",
-  "fixture_corpus.py",
-  "oracle.py",
-  "page_qa.py",
-  "qa_contracts.py",
-  "qa_metrics.py",
-  "worker.py"
- ],
- "resourceFiles": [
-  "_hancom_open_rate.ps1",
-  "_refresh_hwpx_mac.applescript",
-  "_render_hwpx.ps1",
-  "_render_hwpx_mac.applescript"
- ],
- "memberOwners": {
-  "coreContract": [
-   "hwpx.quality.rendering",
-   "hwpx.visual.block_splits",
-   "hwpx.visual.detectors",
-   "hwpx.visual.diff",
-   "hwpx.visual.masks",
-   "hwpx.visual.qa_contracts",
-   "hwpx.visual.report"
+  "canonical": {
+    "status": "canonical",
+    "pythonFiles": 10,
+    "loc": 2718,
+    "manifestSha256": "f5a15541e258e0e2255aad5f864ddbdeb8a43b926c5593b5e95c306390cc5520",
+    "nomenclatureRefrozenFrom": {
+      "loc": 2704,
+      "manifestSha256": "9587ff0e479f7d221e5202a51ee3635293794a16272e1e89a68b9a3dfd1e7676",
+      "reason": "Canonical product ownership wording changed from MCP to automation; protocol and behavior are unchanged."
+    },
+    "frozenAtNote": "S-104 동결값 loc=2001 sha=4b63f85703896fe8…에서 재계산. 코드가 바뀐 게 아니라 소유자가 core에 있던 4개 모듈을 받았기 때문이다. 동결은 드리프트를 막으려는 것이지 이동을 막으려는 것이 아니므로, 이유와 함께 다시 얼린다.",
+    "refrozenFrom": {
+      "loc": 2718,
+      "manifestSha256": "1ecd84fee985862dc93318b545498b151bfc9118b72acff2944b5c20d9121158",
+      "reason": "7.0.4 uses import pymupdf as fitz to prevent legacy import warnings corrupting MCP stdout; ownership, file counts and LOC are unchanged."
+    }
+  },
+  "packageFiles": [
+    "__init__.py",
+    "block_splits.py",
+    "detectors.py",
+    "diff.py",
+    "fixture_corpus.py",
+    "oracle.py",
+    "page_qa.py",
+    "qa_contracts.py",
+    "qa_metrics.py",
+    "worker.py"
   ],
-  "automationRuntime": [
-   "Hancom discovery and binding",
-   "Windows COM and Mac GUI oracle execution",
-   "serialized worker lifecycle and runtime policy",
-   "fixture corpus loading",
-   "page QA and corpus metrics orchestration"
+  "resourceFiles": [
+    "_hancom_open_rate.ps1",
+    "_refresh_hwpx_mac.applescript",
+    "_render_hwpx.ps1",
+    "_render_hwpx_mac.applescript"
   ],
-  "coreCompatibility": [
-   "hwpx.visual.fixture_corpus",
-   "hwpx.visual.hancom_worker",
-   "hwpx.visual.oracle runtime members",
-   "hwpx.visual.page_qa",
-   "hwpx.visual.qa_metrics"
-  ]
- },
- "approvedCoreImports": [
-  "hwpx.quality",
-  "hwpx.quality.rendering",
-  "hwpx.visual.block_splits",
-  "hwpx.visual.detectors",
-  "hwpx.visual.diff",
-  "hwpx.visual.qa_contracts"
- ],
- "approvedSiblingOwners": [],
- "forbiddenCoreCompatibilityImports": [
-  "hwpx.form_fit.seal",
-  "hwpx.form_fit.wordbox",
-  "hwpx.visual.fixture_corpus",
-  "hwpx.visual.hancom_worker",
-  "hwpx.visual.oracle",
-  "hwpx.visual.page_qa",
-  "hwpx.visual.qa_metrics"
- ],
- "productionConsumers": [
-  "hwpx_automation.handlers.layout_style",
-  "hwpx_automation.handlers.specialized",
-  "hwpx_automation.office.authoring",
-  "hwpx_automation.visual_qa"
- ],
- "compatibilityPolicy": {
-  "coreLine": "4.x",
-  "featureWork": "automation canonical owner only",
-  "mirrors": "correctness-or-security-only with parity test and receipt",
-  "removalGate": "public observation followed by a separately approved core major"
- },
- "toolContract": {
-  "default": 122,
-  "advanced": 130,
-  "skillRequired": 29,
-  "hash": "8c278ebd5becba08"
- },
- "packageFilesNote": "이전 6-file 동결에서 10개로 늘었다. 늘어난 4개(block_splits·detectors·diff·qa_contracts)는 신규 코드가 아니라 core가 계속 들고 있던 것이고, 이 소유자의 oracle이 그중 셋을 core에서 import하고 있었다. 5.0 경계 마감으로 실소유자에게 왔다."
+  "memberOwners": {
+    "coreContract": [
+      "hwpx.quality.rendering",
+      "hwpx.visual.block_splits",
+      "hwpx.visual.detectors",
+      "hwpx.visual.diff",
+      "hwpx.visual.masks",
+      "hwpx.visual.qa_contracts",
+      "hwpx.visual.report"
+    ],
+    "automationRuntime": [
+      "Hancom discovery and binding",
+      "Windows COM and Mac GUI oracle execution",
+      "serialized worker lifecycle and runtime policy",
+      "fixture corpus loading",
+      "page QA and corpus metrics orchestration"
+    ],
+    "coreCompatibility": [
+      "hwpx.visual.fixture_corpus",
+      "hwpx.visual.hancom_worker",
+      "hwpx.visual.oracle runtime members",
+      "hwpx.visual.page_qa",
+      "hwpx.visual.qa_metrics"
+    ]
+  },
+  "approvedCoreImports": [
+    "hwpx.quality",
+    "hwpx.quality.rendering",
+    "hwpx.visual.block_splits",
+    "hwpx.visual.detectors",
+    "hwpx.visual.diff",
+    "hwpx.visual.qa_contracts"
+  ],
+  "approvedSiblingOwners": [],
+  "forbiddenCoreCompatibilityImports": [
+    "hwpx.form_fit.seal",
+    "hwpx.form_fit.wordbox",
+    "hwpx.visual.fixture_corpus",
+    "hwpx.visual.hancom_worker",
+    "hwpx.visual.oracle",
+    "hwpx.visual.page_qa",
+    "hwpx.visual.qa_metrics"
+  ],
+  "productionConsumers": [
+    "hwpx_automation.handlers.layout_style",
+    "hwpx_automation.handlers.specialized",
+    "hwpx_automation.office.authoring",
+    "hwpx_automation.visual_qa"
+  ],
+  "compatibilityPolicy": {
+    "coreLine": "4.x",
+    "featureWork": "automation canonical owner only",
+    "mirrors": "correctness-or-security-only with parity test and receipt",
+    "removalGate": "public observation followed by a separately approved core major"
+  },
+  "toolContract": {
+    "default": 122,
+    "advanced": 130,
+    "skillRequired": 29,
+    "hash": "8c278ebd5becba08"
+  },
+  "packageFilesNote": "이전 6-file 동결에서 10개로 늘었다. 늘어난 4개(block_splits·detectors·diff·qa_contracts)는 신규 코드가 아니라 core가 계속 들고 있던 것이고, 이 소유자의 oracle이 그중 셋을 core에서 import하고 있었다. 5.0 경계 마감으로 실소유자에게 왔다."
 }

--- a/docs/hardening_guide_ko.md
+++ b/docs/hardening_guide_ko.md
@@ -96,4 +96,4 @@
   `scripts/conformance/corpus`입니다.
 
 
-> 릴리스 상태 참고: 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.3 · hwpx-plugin 2.0.2입니다 (2026-08-22 왕복 충실도 트레인) (python-hwpx 6.2.1 released 2026-08-19, Windows 편집기 표면 core-only 트레인 — v6.2.0은 보존된 실패 태그).
+> 릴리스 상태: unreleased-candidate. 7.0.4 후보이며 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.3 · hwpx-plugin 2.0.3입니다. 후보 공개 발행은 아직 관찰하지 않았습니다.

--- a/docs/hardening_guide_ko.md
+++ b/docs/hardening_guide_ko.md
@@ -96,4 +96,4 @@
   `scripts/conformance/corpus`입니다.
 
 
-> 릴리스 상태: unreleased-candidate. 7.0.4 후보이며 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.3 · hwpx-plugin 2.0.3입니다. 후보 공개 발행은 아직 관찰하지 않았습니다.
+> 릴리스 상태: release-approved. 7.0.4 후보이며 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.3 · hwpx-plugin 2.0.3입니다. 후보 공개 발행은 아직 관찰하지 않았습니다.

--- a/docs/skill-first-workflows.md
+++ b/docs/skill-first-workflows.md
@@ -170,4 +170,4 @@ Reason:
 If future workflow prompting becomes important, keep the contract narrow and register it against the active FastMCP surface instead of reviving legacy behavior by default.
 
 
-> 릴리스 상태: unreleased-candidate. 7.0.4 후보이며 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.3 · hwpx-plugin 2.0.3입니다. 후보 공개 발행은 아직 관찰하지 않았습니다.
+> 릴리스 상태: release-approved. 7.0.4 후보이며 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.3 · hwpx-plugin 2.0.3입니다. 후보 공개 발행은 아직 관찰하지 않았습니다.

--- a/docs/skill-first-workflows.md
+++ b/docs/skill-first-workflows.md
@@ -170,4 +170,4 @@ Reason:
 If future workflow prompting becomes important, keep the contract narrow and register it against the active FastMCP surface instead of reviving legacy behavior by default.
 
 
-> 릴리스 상태 참고: 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.3 · hwpx-plugin 2.0.2입니다 (2026-08-22 왕복 충실도 트레인) (python-hwpx 6.2.1 released 2026-08-19, Windows 편집기 표면 core-only 트레인 — v6.2.0은 보존된 실패 태그).
+> 릴리스 상태: unreleased-candidate. 7.0.4 후보이며 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.3 · hwpx-plugin 2.0.3입니다. 후보 공개 발행은 아직 관찰하지 않았습니다.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -2,7 +2,7 @@
 
 > Python 자동화와 선택 MCP 어댑터로 여는 한글(HWPX) 문서 워크플로
 >
-> 릴리스 상태: `unreleased-candidate` — 아직 공개되지 않은 7.0.4 source candidate입니다.
+> 릴리스 상태: `release-approved` — 아직 공개되지 않은 7.0.4 source candidate입니다.
 > 현재 공개 트레인은 `python-hwpx 6.3.0 → python-hwpx-automation 7.0.3 → hwpx-plugin 2.0.3`입니다.
 
 ---

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -2,8 +2,8 @@
 
 > Python 자동화와 선택 MCP 어댑터로 여는 한글(HWPX) 문서 워크플로
 >
-> 릴리스 상태: `released` (2026-08-03) — 현재 공개 트레인은
-> `python-hwpx 5.6.0 → python-hwpx-automation 6.6.4 → hwpx-plugin 1.6.0`입니다.
+> 릴리스 상태: `unreleased-candidate` — 아직 공개되지 않은 7.0.4 source candidate입니다.
+> 현재 공개 트레인은 `python-hwpx 6.3.0 → python-hwpx-automation 7.0.3 → hwpx-plugin 2.0.3`입니다.
 
 ---
 
@@ -15,11 +15,10 @@
 
 기존에는 한글 파일을 열어서 일일이 수작업으로 처리해야 했던 일을, 이제 자연어 요청으로 자동화할 수 있습니다.
 
-이 문서는 공개 릴리스 `python-hwpx-automation 6.7.1` 기준입니다. 공개
-트레인은 `python-hwpx 5.7.0 → python-hwpx-automation 6.7.1 →
-hwpx-plugin 1.7.0`, 계약 해시는 `98510af22d13899c`입니다.
+이 문서는 `python-hwpx-automation 7.0.4` 후보 기준입니다. 후보와 현재 공개
+트레인의 계약 해시는 `8c278ebd5becba08`로 같습니다.
 
-6.7.1 릴리스의 기본 모드 128개(고급 모드 포함 총 136개)의 도구로 문서 생성,
+후보의 기본 모드 128개(고급 모드 포함 총 136개)의 도구로 문서 생성,
 선언형 document-plan 생성, 선언적 편집 계획 실행(`run_edit_plan` —
 다단 편집을 all-or-nothing 원자 실행), 누름틀 필드 저작(`add_form_field`),
 네이티브 수식 저작(`add_equation`, LaTeX→EqEdit), 네이티브 차트 생성
@@ -28,9 +27,9 @@ hwpx-plugin 1.7.0`, 계약 해시는 `98510af22d13899c`입니다.
 `format_table`로), HWPX repair/recover까지 처리할 수 있습니다.
 
 document-plan, form-fill, visual-review handoff 워크플로의 문서화·테스트
-기준 upstream 버전 바닥은 `python-hwpx >= 5.7.0`입니다. 설치 계약은 기본
-128개/고급 136개/스킬 필수 28개이며, automation 바닥은 `6.5.0`, skill
-바닥은 `1.6.0`입니다.
+기준 upstream 버전 바닥은 `python-hwpx >= 6.3.0`입니다. 설치 계약은 기본
+128개/고급 136개/스킬 필수 29개이며, automation 바닥은 `7.0.1`, skill
+바닥은 `2.0.0`입니다.
 호환·deprecated 도구는
 2026-10-31까지 모두 유지하며, 신규 호출의 canonical 경로와 rollback은
 [compatibility observation](compatibility-observation.md)을 따릅니다.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-hwpx-automation"
-version = "7.0.3"
+version = "7.0.4"
 description = "Task-oriented HWPX document automation for Python, with an optional MCP adapter."
 readme = "README.md"
 authors = [{ name = "Kohkyuhyun" }]

--- a/src/hwpx_automation/handlers/quality_render.py
+++ b/src/hwpx_automation/handlers/quality_render.py
@@ -272,6 +272,41 @@ def describe_capabilities(domain: str | None = None) -> dict:
     return report
 
 
+_STACK_UPDATE_STATE_SCHEMA = "hwpx.stack-update-state.v1"
+
+
+def _stack_update_block() -> dict[str, Any]:
+    """Launcher-managed runtime update state (hwpx-plugins Feature 066).
+
+    The bundled launcher writes update-state.json and passes its path as
+    HWPX_STACK_UPDATE_STATE. Without it the runtime is not launcher-managed
+    (pip install, editable checkout, plain uvx) and the block says so; it
+    never guesses.
+    """
+    path = os.environ.get("HWPX_STACK_UPDATE_STATE")
+    if not path:
+        return {"available": False, "reason": "NOT_MANAGED"}
+    try:
+        with open(path, encoding="utf-8") as handle:
+            state = json.load(handle)
+    except FileNotFoundError:
+        return {"available": False, "reason": "STATE_MISSING", "path": path}
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return {"available": False, "reason": "STATE_UNREADABLE", "path": path, "detail": str(exc)}
+    if not isinstance(state, dict) or state.get("schemaVersion") != _STACK_UPDATE_STATE_SCHEMA:
+        return {"available": False, "reason": "STATE_SCHEMA_UNKNOWN", "path": path}
+    return {
+        "available": True,
+        "path": path,
+        "checkedAt": state.get("checkedAt"),
+        "autoUpdate": state.get("autoUpdate"),
+        "channel": state.get("channel"),
+        "runtime": state.get("runtime"),
+        "pluginBundle": state.get("pluginBundle"),
+        "lastError": state.get("lastError"),
+    }
+
+
 def mcp_server_health() -> dict:
     """MCP 서버 transport와 timeout/keepalive 점검 정보를 반환합니다."""
     transport = env_value("TRANSPORT", "stdio")
@@ -386,6 +421,7 @@ def mcp_server_health() -> dict:
             ),
         },
         "capability": _capability_block(skew_detected, surface_details),
+        "stackUpdate": _stack_update_block(),
         "unitPolicy": {
             "status": "audited",
             "fontSize": "points",

--- a/src/hwpx_automation/handlers/quality_render.py
+++ b/src/hwpx_automation/handlers/quality_render.py
@@ -295,13 +295,32 @@ def _stack_update_block() -> dict[str, Any]:
         return {"available": False, "reason": "STATE_UNREADABLE", "path": path, "detail": str(exc)}
     if not isinstance(state, dict) or state.get("schemaVersion") != _STACK_UPDATE_STATE_SCHEMA:
         return {"available": False, "reason": "STATE_SCHEMA_UNKNOWN", "path": path}
+    runtime = state.get("runtime")
+    if not isinstance(runtime, dict):
+        return {"available": False, "reason": "STATE_INVALID", "path": path}
+    installed = runtime.get("installed")
+    if (
+        not isinstance(installed, dict)
+        or set(installed) != {"python-hwpx", "python-hwpx-automation"}
+        or not all(isinstance(value, str) and value for value in installed.values())
+    ):
+        return {"available": False, "reason": "STATE_INVALID", "path": path}
+    running = {
+        "python-hwpx": _package_version("python-hwpx"),
+        "python-hwpx-automation": _package_version("python-hwpx-automation"),
+    }
+    runtime = {
+        **runtime,
+        "running": running,
+        "restartRequired": runtime["installed"] != running,
+    }
     return {
         "available": True,
         "path": path,
         "checkedAt": state.get("checkedAt"),
         "autoUpdate": state.get("autoUpdate"),
         "channel": state.get("channel"),
-        "runtime": state.get("runtime"),
+        "runtime": runtime,
         "pluginBundle": state.get("pluginBundle"),
         "lastError": state.get("lastError"),
     }

--- a/src/hwpx_automation/identity.json
+++ b/src/hwpx_automation/identity.json
@@ -3,21 +3,21 @@
   "product": "python-hwpx-automation",
   "releaseMajor": 6,
   "releaseState": {
-    "status": "released",
+    "status": "unreleased-candidate",
     "candidate": {
       "pythonHwpx": "6.3.0",
       "canonicalDistribution": "python-hwpx-automation",
-      "canonicalAutomation": "7.0.3",
+      "canonicalAutomation": "7.0.4",
       "compatibilityDistribution": "hwpx-mcp-server",
-      "compatibility": "7.0.3",
-      "plugin": "2.0.2",
+      "compatibility": "7.0.4",
+      "plugin": "2.1.0",
       "contractHash": "8c278ebd5becba08"
     },
     "currentPublic": {
       "pythonHwpx": "6.3.0",
       "primaryDistribution": "python-hwpx-automation",
       "primaryApplication": "7.0.3",
-      "plugin": "2.0.2",
+      "plugin": "2.0.3",
       "contractHash": "8c278ebd5becba08"
     },
     "promotionGate": "Three states are mandatory: unreleased-candidate while auditing; release-approved only after separate owner approval and while currentPublic still names the previously observed coherent stack; released only in a follow-up commit after remote truth is observed for core, canonical automation, the compatibility distribution, the plugin GitHub release, the marketplace entry, and a real marketplace install. The automation tag workflow publishes only release-approved, leaves currentPublic unchanged, and hands an attached receipt to plugin publication."

--- a/src/hwpx_automation/identity.json
+++ b/src/hwpx_automation/identity.json
@@ -3,7 +3,7 @@
   "product": "python-hwpx-automation",
   "releaseMajor": 6,
   "releaseState": {
-    "status": "unreleased-candidate",
+    "status": "release-approved",
     "candidate": {
       "pythonHwpx": "6.3.0",
       "canonicalDistribution": "python-hwpx-automation",

--- a/src/hwpx_automation/office/authoring/__init__.py
+++ b/src/hwpx_automation/office/authoring/__init__.py
@@ -1292,7 +1292,7 @@ def inspect_document_authoring_quality(
                     _rendered = _mac.render_pdf(str(_hwpx), str(_pdf))
                     if _rendered and Path(_rendered).exists():
                         try:
-                            import fitz as _fitz
+                            import pymupdf as _fitz
 
                             _doc = _fitz.open(_rendered)
                             _has_text = any(

--- a/src/hwpx_automation/office/form_fill/fit/wordbox.py
+++ b/src/hwpx_automation/office/form_fill/fit/wordbox.py
@@ -185,7 +185,7 @@ def fitz_available() -> bool:
     """True when PyMuPDF (``fitz``) can be imported (the extraction backend)."""
 
     try:  # pragma: no cover - trivial import probe
-        import fitz  # noqa: F401
+        import pymupdf as fitz  # noqa: F401
     except Exception:
         return False
     return True
@@ -205,7 +205,7 @@ def extract_word_boxes(pdf_path: str, *, page: int | None = None) -> list[WordBo
 
     if not fitz_available():
         raise OracleUnavailable("PyMuPDF (fitz) is not installed")
-    import fitz
+    import pymupdf as fitz
 
     boxes: list[WordBox] = []
     try:
@@ -255,7 +255,7 @@ def extract_glyph_boxes(pdf_path: str, *, page: int | None = None) -> list[WordB
 
     if not fitz_available():
         raise OracleUnavailable("PyMuPDF (fitz) is not installed")
-    import fitz
+    import pymupdf as fitz
 
     boxes: list[WordBox] = []
     try:
@@ -709,7 +709,7 @@ def render_glyph_boxes(
         if not pdf or not os.path.exists(pdf) or os.path.getsize(pdf) == 0:
             raise OracleUnavailable("Hancom render produced no PDF")
         boxes = extract_glyph_boxes(pdf, page=page)
-        import fitz
+        import pymupdf as fitz
 
         with fitz.open(pdf) as doc:
             if len(doc) == 0:  # a 0-page render is a failed render, not a clean pass
@@ -742,7 +742,7 @@ def extract_cell_clips(pdf_path: str, *, page: int | None = None) -> list[Rect]:
 
     if not fitz_available():
         raise OracleUnavailable("PyMuPDF (fitz) is not installed")
-    import fitz
+    import pymupdf as fitz
 
     clips: list[Rect] = []
     try:
@@ -785,7 +785,7 @@ def extract_image_boxes(pdf_path: str, *, page: int | None = None) -> list[Rect]
 
     if not fitz_available():
         raise OracleUnavailable("PyMuPDF (fitz) is not installed")
-    import fitz
+    import pymupdf as fitz
 
     boxes: list[Rect] = []
     try:
@@ -843,7 +843,7 @@ def render_form_geometry(
                 raise OracleUnavailable("Hancom render produced no PDF")
             glyphs = extract_glyph_boxes(rendered, page=page)
             clips = extract_cell_clips(rendered, page=page)
-            import fitz
+            import pymupdf as fitz
 
             with fitz.open(rendered) as doc:
                 if len(doc) == 0:
@@ -957,7 +957,7 @@ def extract_layout_signature(pdf_path: str) -> LayoutSignature:
 
     if not fitz_available():
         raise OracleUnavailable("PyMuPDF (fitz) is not installed")
-    import fitz
+    import pymupdf as fitz
 
     try:
         doc = fitz.open(pdf_path)

--- a/src/hwpx_automation/office/form_fill/quality.py
+++ b/src/hwpx_automation/office/form_fill/quality.py
@@ -180,7 +180,7 @@ def detect_overflow_crossings(
     PyMuPDF; raises ``RuntimeError`` if unavailable (caller degrades to unverified).
     """
     try:
-        import fitz
+        import pymupdf as fitz
     except Exception as exc:  # pragma: no cover - env probe
         raise RuntimeError(f"PyMuPDF unavailable: {exc}") from exc
 
@@ -266,7 +266,7 @@ def score_render(
             [f"render imaging deps unavailable: {exc}"],
         )
 
-    import fitz  # already importable if we got here
+    import pymupdf as fitz  # already importable if we got here
 
     doc = fitz.open(pdf)
     pages = doc.page_count

--- a/src/hwpx_automation/office/rendering/diff.py
+++ b/src/hwpx_automation/office/rendering/diff.py
@@ -27,7 +27,7 @@ _TALL_BAND_REL = 1.0
 
 def pymupdf_available() -> bool:
     try:  # pragma: no cover - trivial import probe
-        import fitz  # noqa: F401
+        import pymupdf as fitz  # noqa: F401
     except Exception:
         return False
     return True
@@ -36,7 +36,7 @@ def pymupdf_available() -> bool:
 def render_pdf_to_images(pdf_path: str | Path, dpi: int = 150) -> list["Image.Image"]:
     """Rasterize every page of ``pdf_path`` to a list of RGB ``PIL.Image``."""
 
-    import fitz  # pymupdf
+    import pymupdf as fitz  # pymupdf
     from PIL import Image
 
     pages: list[Image.Image] = []

--- a/src/hwpx_automation/office/rendering/worker.py
+++ b/src/hwpx_automation/office/rendering/worker.py
@@ -255,7 +255,7 @@ class SerializedHancomWorker:
     @staticmethod
     def _rasterize(pdf: Path, destination: Path, dpi: int) -> list[Path]:
         try:
-            import fitz
+            import pymupdf as fitz
         except ImportError as exc:
             raise RuntimeError("PyMuPDF is required for page PNG output") from exc
         document = fitz.open(pdf)

--- a/tests/test_form_fit_wordbox.py
+++ b/tests/test_form_fit_wordbox.py
@@ -772,9 +772,9 @@ def test_extract_layout_signature_uses_borders_only_strategy(monkeypatch):
         def __exit__(self, *exc):
             return False
 
-    stub = types.ModuleType("fitz")
+    stub = types.ModuleType("pymupdf")
     stub.open = lambda _path: _Doc()
-    monkeypatch.setitem(sys.modules, "fitz", stub)
+    monkeypatch.setitem(sys.modules, "pymupdf", stub)
     monkeypatch.setattr(wb, "fitz_available", lambda: True)
 
     wb.extract_layout_signature("/whatever.pdf")

--- a/tests/test_readme_mcp_config.py
+++ b/tests/test_readme_mcp_config.py
@@ -4,10 +4,6 @@ import json
 import re
 from pathlib import Path
 
-try:
-    import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python 3.10
-    import tomli as tomllib
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -20,11 +16,12 @@ def test_readme_host_config_is_parseable_and_resolves_distribution_explicitly() 
     host = next(config for config in configs if "mcpServers" in config)
     server = host["mcpServers"]["hwpx"]
 
-    # The quickstart pin must track the checkout's own version: a frozen
-    # literal here kept the README example fossilized at 6.1.3 for two
-    # major trains.
-    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    version = project["project"]["version"]
+    # The installable quickstart follows observed public truth while a new
+    # candidate is being prepared; publication promotion advances it.
+    identity = json.loads(
+        (ROOT / "src/hwpx_automation/identity.json").read_text(encoding="utf-8")
+    )
+    version = identity["releaseState"]["currentPublic"]["primaryApplication"]
 
     assert server["command"] == "uvx"
     assert server["args"] == [

--- a/tests/test_render_worker_queue_integration.py
+++ b/tests/test_render_worker_queue_integration.py
@@ -9,9 +9,7 @@ import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 
-import pytest
 
-import hwpx
 from hwpx_automation.office.rendering.worker import (
     DeterministicFakeSession,
     SerializedHancomWorker,
@@ -26,27 +24,11 @@ def _resolve_worker_script() -> Path:
     if explicit_script:
         return Path(explicit_script).expanduser().resolve()
 
-    explicit_repo = os.environ.get("PYTHON_HWPX_REPO")
-    if explicit_repo:
-        return Path(explicit_repo).expanduser().resolve() / "scripts" / "hancom_render_worker.py"
-
-    package_file = Path(hwpx.__file__).resolve()
-    source_root = package_file.parent.parent
-    if source_root.name == "src":
-        return source_root.parent / "scripts" / "hancom_render_worker.py"
-    pytest.skip(
-        "hancom_render_worker.py is not included in the installed python-hwpx wheel; "
-        "set HWPX_HANCOM_RENDER_WORKER_SCRIPT to an explicit script",
-        allow_module_level=True,
-    )
+    return Path(__file__).resolve().parents[1] / "scripts" / "hancom_render_worker.py"
 
 
 SCRIPT = _resolve_worker_script()
-if not SCRIPT.is_file():
-    pytest.skip(
-        f"pinned Hancom render worker script is unavailable: {SCRIPT}",
-        allow_module_level=True,
-    )
+assert SCRIPT.is_file(), f"canonical automation render worker script is missing: {SCRIPT}"
 spec = importlib.util.spec_from_file_location("s068_hancom_render_worker", SCRIPT)
 assert spec and spec.loader
 module = importlib.util.module_from_spec(spec)

--- a/tests/test_stack_update_block.py
+++ b/tests/test_stack_update_block.py
@@ -55,3 +55,26 @@ def test_health_reports_missing_unreadable_and_unknown_state(tmp_path: Path, mon
 
 def test_additive_health_field_leaves_the_contract_hash_unchanged() -> None:
     assert contract_hash() == "8c278ebd5becba08"
+
+
+@pytest.mark.parametrize("running_automation, restart", [("7.0.2", True), ("7.0.3", False)])
+def test_health_distinguishes_running_and_prepared_generation(tmp_path, monkeypatch, running_automation, restart):
+    from hwpx_automation.handlers import quality_render
+
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps(STATE))
+    monkeypatch.setenv("HWPX_STACK_UPDATE_STATE", str(path))
+    versions = {"python-hwpx": "6.3.0", "python-hwpx-automation": running_automation}
+    monkeypatch.setattr(quality_render, "_package_version", versions.__getitem__)
+    block = quality_render._stack_update_block()
+    assert block["runtime"]["running"] == versions
+    assert block["runtime"]["installed"] == STATE["runtime"]["installed"]
+    assert block["runtime"]["restartRequired"] is restart
+
+
+@pytest.mark.parametrize("runtime", [None, [], {}, {"installed": []}, {"installed": {}}])
+def test_invalid_runtime_state_fails_closed(tmp_path, monkeypatch, runtime):
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({**STATE, "runtime": runtime}))
+    monkeypatch.setenv("HWPX_STACK_UPDATE_STATE", str(path))
+    assert mcp_server_health()["stackUpdate"]["reason"] == "STATE_INVALID"

--- a/tests/test_stack_update_block.py
+++ b/tests/test_stack_update_block.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""mcp_server_health surfaces the launcher-managed runtime update state (Feature 066 D3)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hwpx_automation.server import mcp_server_health
+from hwpx_automation.tool_contract import contract_hash
+
+STATE = {
+    "schemaVersion": "hwpx.stack-update-state.v1",
+    "checkedAt": "2026-09-04T09:00:00+0900",
+    "autoUpdate": True,
+    "channel": "floor",
+    "runtime": {
+        "installed": {"python-hwpx": "6.3.0", "python-hwpx-automation": "7.0.3"},
+        "latestAvailable": {"python-hwpx": "6.3.0", "python-hwpx-automation": "7.1.0"},
+    },
+    "pluginBundle": {"installed": "2.1.0", "latestKnown": "2.1.1"},
+    "lastError": None,
+}
+
+
+def test_health_reports_not_managed_without_the_state_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HWPX_STACK_UPDATE_STATE", raising=False)
+    assert mcp_server_health()["stackUpdate"] == {"available": False, "reason": "NOT_MANAGED"}
+
+
+def test_health_surfaces_the_launcher_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "update-state.json"
+    path.write_text(json.dumps(STATE), encoding="utf-8")
+    monkeypatch.setenv("HWPX_STACK_UPDATE_STATE", str(path))
+    block = mcp_server_health()["stackUpdate"]
+    assert block["available"] is True and block["path"] == str(path)
+    assert block["pluginBundle"] == {"installed": "2.1.0", "latestKnown": "2.1.1"}
+    assert block["runtime"]["latestAvailable"]["python-hwpx-automation"] == "7.1.0"
+    assert block["lastError"] is None and block["channel"] == "floor" and block["autoUpdate"] is True
+
+
+def test_health_reports_missing_unreadable_and_unknown_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HWPX_STACK_UPDATE_STATE", str(tmp_path / "absent.json"))
+    assert mcp_server_health()["stackUpdate"]["reason"] == "STATE_MISSING"
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    monkeypatch.setenv("HWPX_STACK_UPDATE_STATE", str(bad))
+    assert mcp_server_health()["stackUpdate"]["reason"] == "STATE_UNREADABLE"
+    other = tmp_path / "other.json"
+    other.write_text(json.dumps({"schemaVersion": "something-else"}), encoding="utf-8")
+    monkeypatch.setenv("HWPX_STACK_UPDATE_STATE", str(other))
+    assert mcp_server_health()["stackUpdate"]["reason"] == "STATE_SCHEMA_UNKNOWN"
+
+
+def test_additive_health_field_leaves_the_contract_hash_unchanged() -> None:
+    assert contract_hash() == "8c278ebd5becba08"


### PR DESCRIPTION
Expose managed runtime update health, including the installed generation, running package versions, and restart requirement. Use the canonical PyMuPDF import to keep MCP stdout free of legacy-import warnings, and restore the render worker integration test to the automation-owned worker.

Prepare canonical and compatibility 7.0.4 packages with unchanged core 6.3.0 and tool contract `8c278ebd5becba08`. The train is published and a real marketplace installation was observed. currentPublic was promoted in a follow-up source commit after that observation.

Validation passed: Python3.10–3.14 CI, typing and architecture gates, Windows/macOS clean installs, public legacy upgrade/rollback matrix, release workflow, and installed Codex MCP calls.

Release: https://github.com/airmang/python-hwpx-automation/releases/tag/v7.0.4

Resolves #105.
