### PR TITLE
release: promote observed full stack 6.4.0 / 7.1.0 / 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
   </p>
 </p>
 
-<!-- release-state: release-approved -->
+<!-- release-state: released -->
 > [!NOTE]
-> 이 소스는 발행 승인된(release-approved) 7.1.0 후보입니다. 원격 발행과 실제 설치 관찰 전까지 공개 좌표는 유지합니다.
-> 후보: `python-hwpx 6.4.0 → python-hwpx-automation 7.1.0 → hwpx-plugin 2.2.0` (`ba0211fc854a0a97`).
-> 공개 트레인: `python-hwpx 6.3.0 → python-hwpx-automation 7.0.4 → hwpx-plugin 2.1.0` (`8c278ebd5becba08`).
+> 7.1.0 공개 발행과 전체 트레인의 실제 marketplace 설치를 관찰했습니다.
+> 검증 조합: `python-hwpx 6.4.0 → python-hwpx-automation 7.1.0 → hwpx-plugin 2.2.0` (`ba0211fc854a0a97`).
+> 공개 트레인: `python-hwpx 6.4.0 → python-hwpx-automation 7.1.0 → hwpx-plugin 2.2.0` (`ba0211fc854a0a97`).
 > 공개 좌표는 core·automation PyPI와 plugin GitHub
 > Release·marketplace·실제 marketplace 설치 관찰 후에만 승격합니다.
 > [릴리스 runbook](docs/release-runbook.md)
@@ -73,7 +73,7 @@ Gemini CLI는 `~/.gemini/settings.json`, Cursor·Windsurf는 각 에디터의 MC
       "command": "uvx",
       "args": [
         "--from",
-        "python-hwpx-automation[mcp]==7.0.4",
+        "python-hwpx-automation[mcp]==7.1.0",
         "hwpx-automation-mcp"
       ],
       "env": {

--- a/docs/hardening_guide_ko.md
+++ b/docs/hardening_guide_ko.md
@@ -96,4 +96,4 @@
   `scripts/conformance/corpus`입니다.
 
 
-> 릴리스 상태: release-approved. 7.1.0 후보이며 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.4 · hwpx-plugin 2.1.0입니다. 후보 공개 발행은 아직 관찰하지 않았습니다.
+> 릴리스 상태: released. 7.1.0 공개 릴리스이며 현재 공개 트레인은 python-hwpx 6.4.0 · python-hwpx-automation 7.1.0 · hwpx-plugin 2.2.0입니다. 공개 발행과 실제 marketplace 설치 관찰을 완료했습니다.

--- a/docs/releases/2026-09-09-existing-edit-stack.md
+++ b/docs/releases/2026-09-09-existing-edit-stack.md
@@ -1,0 +1,14 @@
+# Existing-edit stack release verification — 2026-09-09
+
+Public train: python-hwpx 6.4.0, python-hwpx-automation 7.1.0, hwpx-mcp-server compatibility 7.1.0, hwpx-plugin 2.2.0. Contract `ba0211fc854a0a97` (floor-only change from `8c278ebd5becba08`; 128 default / 136 advanced / 29 skill-required tools unchanged).
+
+- [Core release](https://github.com/airmang/python-hwpx/releases/tag/v6.4.0): wheel `1cc08533…4a48` and sdist observed on PyPI; [release workflow](https://github.com/airmang/python-hwpx/actions/runs/34366258536) succeeded (legacy cap, prepublish, release, hash verification).
+- [Automation release](https://github.com/airmang/python-hwpx-automation/releases/tag/v7.1.0): canonical wheel `f957042e…b6e2` and compatibility wheel `6a739b46…0a2f` observed on PyPI; [release workflow](https://github.com/airmang/python-hwpx-automation/actions/runs/34369172628) succeeded and attached the release-approved plugin handoff receipt.
+- [Plugin release](https://github.com/airmang/hwpx-plugins/releases/tag/v2.2.0): public marketplace installed by Codex 0.153.4 (`codex plugin marketplace add airmang/hwpx-plugins`, `codex plugin add hwpx-plugin@hwpx` → 2.2.0). A fresh ephemeral app-server session, with no model turn, called `mcp_server_health` and `describe_capabilities` through the installed plugin.
+- Native Codex observed core 6.4.0 / automation 7.1.0 / plugin 2.2.0, 128 default tools bound to contract `ba0211fc854a0a97` (binding `a5551276d1465838`, no mismatches). The managed launcher built a new generation `gen-6.4.0-7.1.0`; installed and running versions matched, `restartRequired=false`, `lastError=null`.
+- A fresh venv `pip install python-hwpx-automation[mcp]==7.1.0 hwpx-mcp-server==7.1.0` resolved core 6.4.0 and served 128 tools over stdio. The first resolver attempt right after upload hit PyPI simple-index propagation lag; the retry succeeded.
+- Source CI: [automation PR #108](https://github.com/airmang/python-hwpx-automation/pull/108) 14/14 checks (Python 3.10–3.14, clean package installs, macOS/Windows oracle boundary, release-gate dry run, windows-publish-gate); [plugin PR #31](https://github.com/airmang/hwpx-plugins/pull/31) plugin-contract passed; [core PR #97](https://github.com/airmang/python-hwpx/pull/97) 13/13. Local compat matrix against the core 6.4.0 wheel passed all five shapes including legacy 5.1.1 / core 4.2.0 upgrade and full rollback.
+
+The release tags and PyPI artifacts retain `release-approved` as the publication-time snapshot. Only this follow-up source commit promotes `currentPublic` to the observed full train; immutable artifacts are not rewritten.
+
+A successful installation is not a multi-day update observation or a real Hancom rendering verdict; the advanced 136-tool runtime was not re-observed for this train. Receiving a future upstream release without a plugin change and observations over three releases remain longitudinal follow-ups.

--- a/docs/skill-first-workflows.md
+++ b/docs/skill-first-workflows.md
@@ -170,4 +170,4 @@ Reason:
 If future workflow prompting becomes important, keep the contract narrow and register it against the active FastMCP surface instead of reviving legacy behavior by default.
 
 
-> 릴리스 상태: release-approved. 7.1.0 후보이며 현재 공개 트레인은 python-hwpx 6.3.0 · python-hwpx-automation 7.0.4 · hwpx-plugin 2.1.0입니다. 후보 공개 발행은 아직 관찰하지 않았습니다.
+> 릴리스 상태: released. 7.1.0 공개 릴리스이며 현재 공개 트레인은 python-hwpx 6.4.0 · python-hwpx-automation 7.1.0 · hwpx-plugin 2.2.0입니다. 공개 발행과 실제 marketplace 설치 관찰을 완료했습니다.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -2,8 +2,8 @@
 
 > Python 자동화와 선택 MCP 어댑터로 여는 한글(HWPX) 문서 워크플로
 >
-> 릴리스 상태: `release-approved` — 발행 승인됐지만 아직 원격 관찰 전인 7.1.0 source candidate입니다.
-> 현재 공개 트레인은 `python-hwpx 6.3.0 → python-hwpx-automation 7.0.4 → hwpx-plugin 2.1.0`입니다.
+> 릴리스 상태: `released` — 7.1.0 공개 릴리스이며 실제 marketplace 설치를 관찰했습니다.
+> 현재 공개 트레인은 `python-hwpx 6.4.0 → python-hwpx-automation 7.1.0 → hwpx-plugin 2.2.0`입니다.
 
 ---
 
@@ -15,9 +15,9 @@
 
 기존에는 한글 파일을 열어서 일일이 수작업으로 처리해야 했던 일을, 이제 자연어 요청으로 자동화할 수 있습니다.
 
-후보 계약은 `ba0211fc854a0a97`, 현재 공개 트레인의 계약은 `8c278ebd5becba08`입니다.
+현재 공개 트레인의 계약은 `ba0211fc854a0a97`입니다(이전 공개 계약 `8c278ebd5becba08`에서 floor만 변경).
 
-후보의 기본 모드 128개(고급 모드 포함 총 136개)의 도구로 문서 생성,
+기본 모드 128개(고급 모드 포함 총 136개)의 도구로 문서 생성,
 선언형 document-plan 생성, 선언적 편집 계획 실행(`run_edit_plan` —
 다단 편집을 all-or-nothing 원자 실행), 누름틀 필드 저작(`add_form_field`),
 네이티브 수식 저작(`add_equation`, LaTeX→EqEdit), 네이티브 차트 생성

--- a/src/hwpx_automation/identity.json
+++ b/src/hwpx_automation/identity.json
@@ -3,7 +3,7 @@
   "product": "python-hwpx-automation",
   "releaseMajor": 6,
   "releaseState": {
-    "status": "release-approved",
+    "status": "released",
     "candidate": {
       "pythonHwpx": "6.4.0",
       "canonicalDistribution": "python-hwpx-automation",
@@ -14,11 +14,11 @@
       "contractHash": "ba0211fc854a0a97"
     },
     "currentPublic": {
-      "pythonHwpx": "6.3.0",
+      "pythonHwpx": "6.4.0",
       "primaryDistribution": "python-hwpx-automation",
-      "primaryApplication": "7.0.4",
-      "plugin": "2.1.0",
-      "contractHash": "8c278ebd5becba08"
+      "primaryApplication": "7.1.0",
+      "plugin": "2.2.0",
+      "contractHash": "ba0211fc854a0a97"
     },
     "promotionGate": "Three states are mandatory: unreleased-candidate while auditing; release-approved only after separate owner approval and while currentPublic still names the previously observed coherent stack; released only in a follow-up commit after remote truth is observed for core, canonical automation, the compatibility distribution, the plugin GitHub release, the marketplace entry, and a real marketplace install. The automation tag workflow publishes only release-approved, leaves currentPublic unchanged, and hands an attached receipt to plugin publication.",
     "previousPublic": {
@@ -27,6 +27,12 @@
       "primaryApplication": "7.0.4",
       "plugin": "2.1.0",
       "contractHash": "8c278ebd5becba08"
+    },
+    "publicationEvidence": {
+      "pluginVersion": "2.2.0",
+      "installObserved": true,
+      "observedAt": "2026-09-09T15:36:45.406420+00:00",
+      "releaseUrl": "https://github.com/airmang/hwpx-plugins/releases/tag/v2.2.0"
     }
   },
   "releaseFloors": {


### PR DESCRIPTION
Follow-up promotion commit after remote truth was observed for the whole train (core v6.4.0, automation/compat v7.1.0, plugin v2.2.0, real Codex marketplace install with 128 tools bound to `ba0211fc854a0a97`). Sets `releaseState.status=released`, promotes `currentPublic`, records `publicationEvidence`, updates the README marker and current-facing guides, and adds the release verification doc. Tags and PyPI artifacts remain the release-approved snapshot.

Refs #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)